### PR TITLE
chore: align AWS CDK CLI and library versions to 2.177.0

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/node": "20.10.4",
-    "aws-cdk": "2.118.0",
+    "aws-cdk": "2.177.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Align AWS CDK Versions

### Changes
- Updated `aws-cdk` CLI tool version in `devDependencies` from 2.118.0 to 2.177.0.

### Rationale
- Resolved version mismatch between `aws-cdk` (CLI tool) and `aws-cdk-lib` (core library).
- Currently, `aws-cdk-lib` is using version 2.177.0 while the CLI was using 2.118.0.
- Aligning these package versions prevents potential compatibility issues and ensures consistency in CDK functionality.

### Testing
- Confirmed existing stacks and constructs work properly with the updated version.

This change does not affect code functionality and only improves version consistency.